### PR TITLE
Delete "non-representative" lighthouse runs

### DIFF
--- a/src/lighthouse/cleanup.js
+++ b/src/lighthouse/cleanup.js
@@ -2,8 +2,6 @@
 const fs = require( 'fs' );
 const path = require( 'path' );
 
-const CI_ROOT = '/home/runner/work/cfgov-lighthouse/cfgov-lighthouse/';
-
 /**
  * Takes a summary report and deletes all "non-representative" runs from
  * the filesystem to save disk space.
@@ -13,8 +11,9 @@ const cleanUpRuns = summaryReport => {
 
   summaryReport.nonRepresentativeRuns.forEach( run => {
 
-    const filePath = path.join( __dirname, '../../', run.jsonPath.replace( CI_ROOT, '' ) );
-    const fileName = filePath.split( '/' ).pop();
+    const fileName = path.basename( run.jsonPath );
+    const fileDir = path.basename( path.dirname( run.jsonPath ) );
+    const filePath = path.join( __dirname, '../../docs/reports/', fileDir, fileName );
 
     fs.unlink( filePath, err => {
       if ( err ) {

--- a/src/lighthouse/cleanup.js
+++ b/src/lighthouse/cleanup.js
@@ -7,7 +7,7 @@ const CI_ROOT = '/home/runner/work/cfgov-lighthouse/cfgov-lighthouse/';
 /**
  * Takes a summary report and deletes all "non-representative" runs from
  * the filesystem to save disk space.
- * @param {object} summaryReport A LighthouseSummaryReport (see reports.js)
+ * @param {Object} summaryReport A LighthouseSummaryReport (see reports.js)
  */
 const cleanUpRuns = summaryReport => {
 
@@ -20,7 +20,7 @@ const cleanUpRuns = summaryReport => {
       if ( err ) {
         return console.error( `Tried to delete ${ fileName } but failed. It might already be deleted.` );
       }
-      console.log( `Deleted non-representative run ${ fileName }.` );
+      return console.log( `Deleted non-representative run ${ fileName }.` );
     } );
 
   } );

--- a/src/lighthouse/cleanup.js
+++ b/src/lighthouse/cleanup.js
@@ -1,0 +1,29 @@
+/* eslint-disable no-console */
+const fs = require( 'fs' );
+const path = require( 'path' );
+
+const CI_ROOT = '/home/runner/work/cfgov-lighthouse/cfgov-lighthouse/';
+
+/**
+ * Takes a summary report and deletes all "non-representative" runs from
+ * the filesystem to save disk space.
+ * @param {object} summaryReport A LighthouseSummaryReport (see reports.js)
+ */
+const cleanUpRuns = summaryReport => {
+
+  summaryReport.nonRepresentativeRuns.forEach( run => {
+
+    const filePath = path.join( __dirname, '../../', run.jsonPath.replace( CI_ROOT, '' ) );
+    const fileName = filePath.split( '/' ).pop();
+
+    fs.unlink( filePath, err => {
+      if ( err ) {
+        return console.error( `Tried to delete ${ fileName } but failed. It might already be deleted.` );
+      }
+      console.log( `Deleted non-representative run ${ fileName }.` );
+    } );
+
+  } );
+};
+
+module.exports = cleanUpRuns;

--- a/src/lighthouse/reports.js
+++ b/src/lighthouse/reports.js
@@ -19,6 +19,7 @@ class LighthouseSummaryReport {
     );
 
     this.pages = this._parseManifest( this._manifestFilename );
+    this.nonRepresentativeRuns = this._getNonRepresentativeRuns( this._manifestFilename );
   }
 
   _parseManifest( manifestFilename ) {
@@ -50,6 +51,17 @@ class LighthouseSummaryReport {
     } );
 
     return pages.sort( ( a, b ) => a.url > b.url );
+  }
+
+  _getNonRepresentativeRuns( manifestFilename ) {
+    // eslint-disable-next-line no-sync
+    const manifest = JSON.parse( fs.readFileSync( manifestFilename ) );
+
+    const nonRepresentativeRuns = manifest.filter(
+      run => !run.isRepresentativeRun
+    );
+
+    return nonRepresentativeRuns;
   }
 
   _groupBy( seq, keyGetter ) {

--- a/src/lighthouse/reports.js
+++ b/src/lighthouse/reports.js
@@ -19,7 +19,7 @@ class LighthouseSummaryReport {
     );
 
     this.pages = this._parseManifest( this._manifestFilename );
-    this.nonRepresentativeRuns = this._getNonRepresentativeRuns( this._manifestFilename );
+    this.nonRepresentativeRuns = this._getNonRepRuns( this._manifestFilename );
   }
 
   _parseManifest( manifestFilename ) {
@@ -53,7 +53,7 @@ class LighthouseSummaryReport {
     return pages.sort( ( a, b ) => a.url > b.url );
   }
 
-  _getNonRepresentativeRuns( manifestFilename ) {
+  _getNonRepRuns( manifestFilename ) {
     // eslint-disable-next-line no-sync
     const manifest = JSON.parse( fs.readFileSync( manifestFilename ) );
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,7 @@ const {
   REPORTS_ROOT
 } = require( './src/lighthouse/reports' );
 
+const cleanUpRuns = require( './src/lighthouse/cleanup' );
 
 /**
  * Create plugin to generate HTML files using Nunjucks templates. Plugin will
@@ -30,6 +31,8 @@ function buildReportPlugin() {
   const latestTimestamp = timestamps[timestamps.length - 1];
 
   const summaryReport = new LighthouseSummaryReport( latestTimestamp );
+
+  cleanUpRuns( summaryReport );
 
   const nunjucksEnvironment = nunjucks.configure();
   nunjucksEnvironment.addFilter( 'date', nunjucksDateFilter );


### PR DESCRIPTION
Lighthouse runs three times when testing a page and uses the median run for its final values. The median run that's used is referred to as the "representative" run. The non-representative runs' JSON files are unnecessarily left in the /reports directory. This PR adds a script to delete them.

## Additions

- Script to delete unneeded runs

## Testing

1. Run `yarn && yarn serve` locally and you should see some messages about files being deleted.