### PR TITLE
Index page design tweaks

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -26,9 +26,9 @@
   <thead>
     <tr>
       <th>Cf.gov Page</th>
-      <th>Mobile scores</th>
-      <th>Desktop scores</th>
-      <th>Reports</th>
+      <th>MOBILE REPORT</th>
+      <th>DESKTOP REPORT</th>
+      <th>HISTORY</th>
     </tr>
   </thead>
   <tbody>
@@ -41,186 +41,240 @@
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+                
+              
 
-            <strong>90</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_-2020_10_05_00_42_20.report.json#performance">
+                Performance <strong>90</strong>
+              </a>
 
-            
-            
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>98</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+                
+              
 
-            
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_-2020_10_05_00_42_20.report.json#accessibility">
+                Accessibility <strong>98</strong>
+              </a>
 
-            <strong>85</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_-2020_10_05_00_42_20.report.json#best-practices">
+                Best practices <strong>85</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>54</strong> Pwa
-          </li>
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_-2020_10_05_00_42_20.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_-2020_10_05_00_42_20.report.json">
+            View full mobile report
+          </a>
+        </div>
+
       </td>
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
+            <li class="m-list_item">
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
 
-            
-            
+              
+                
+              
 
-            <strong>54</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_-2020_10_05_00_26_12.report.json#performance">
+                Performance <strong>54</strong>
+              </a>
 
-            
-            
+              
+              
 
-            
-            
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>98</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_-2020_10_05_00_26_12.report.json#accessibility">
+                Accessibility <strong>98</strong>
+              </a>
 
-            <strong>92</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_-2020_10_05_00_26_12.report.json#best-practices">
+                Best practices <strong>92</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>52</strong> Pwa
-          </li>
+              
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_-2020_10_05_00_26_12.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_-2020_10_05_00_26_12.report.json">
+            View full desktop report
+          </a>
+        </div>
+
       </td>
       
       <td>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_-2020_10_05_00_42_20.report.json"
-          >
-            View mobile report
-          </a>
-        </div>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_-2020_10_05_00_26_12.report.json"
-          >
-            View desktop report
-          </a>
-        </div>
-        
+        <a class="report-link"
+           href="#">
+          View report history
+          (coming soon)
+        </a>
       </td>
     </tr>
     
@@ -232,186 +286,246 @@
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
+            <li class="m-list_item">
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
 
-            
-            
+              
+                
+              
 
-            <strong>84</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_-2020_10_05_00_42_33.report.json#performance">
+                Performance <strong>84</strong>
+              </a>
 
-            
-            
+              
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
 
+            </li>
             
-            
+          
+          
 
-            <strong>87</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+                
+              
 
-            
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_-2020_10_05_00_42_33.report.json#accessibility">
+                Accessibility <strong>87</strong>
+              </a>
 
-            <strong>85</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_-2020_10_05_00_42_33.report.json#best-practices">
+                Best practices <strong>85</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>54</strong> Pwa
-          </li>
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_-2020_10_05_00_42_33.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_-2020_10_05_00_42_33.report.json">
+            View full mobile report
+          </a>
+        </div>
+
       </td>
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
+            <li class="m-list_item">
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
 
-            
-            
+              
+                
+              
 
-            <strong>64</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_-2020_10_05_00_26_55.report.json#performance">
+                Performance <strong>64</strong>
+              </a>
 
-            
-            
+              
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
 
+            </li>
             
-            
+          
+          
 
-            <strong>87</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_-2020_10_05_00_26_55.report.json#accessibility">
+                Accessibility <strong>87</strong>
+              </a>
 
-            <strong>92</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_-2020_10_05_00_26_55.report.json#best-practices">
+                Best practices <strong>92</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>52</strong> Pwa
-          </li>
+              
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_-2020_10_05_00_26_55.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_-2020_10_05_00_26_55.report.json">
+            View full desktop report
+          </a>
+        </div>
+
       </td>
       
       <td>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_-2020_10_05_00_42_33.report.json"
-          >
-            View mobile report
-          </a>
-        </div>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_-2020_10_05_00_26_55.report.json"
-          >
-            View desktop report
-          </a>
-        </div>
-        
+        <a class="report-link"
+           href="#">
+          View report history
+          (coming soon)
+        </a>
       </td>
     </tr>
     
@@ -423,186 +537,242 @@
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
+            <li class="m-list_item">
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
 
-            
-            
+              
+                
+              
 
-            <strong>71</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_economic_impact_payment_prepaid_card_-2020_10_05_00_43_44.report.json#performance">
+                Performance <strong>71</strong>
+              </a>
 
-            
-            
+              
+              
 
-            
-            
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>95</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+                
+              
 
-            
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_economic_impact_payment_prepaid_card_-2020_10_05_00_43_44.report.json#accessibility">
+                Accessibility <strong>95</strong>
+              </a>
 
-            <strong>85</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
-            <svg class="u-fill-red cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
-            
+              
+                
+              
 
-            
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_economic_impact_payment_prepaid_card_-2020_10_05_00_43_44.report.json#best-practices">
+                Best practices <strong>85</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>29</strong> Pwa
-          </li>
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_economic_impact_payment_prepaid_card_-2020_10_05_00_43_44.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_economic_impact_payment_prepaid_card_-2020_10_05_00_43_44.report.json">
+            View full mobile report
+          </a>
+        </div>
+
       </td>
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
-            <svg class="u-fill-red cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
+              
+                
+              
 
-            <strong>45</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_economic_impact_payment_prepaid_card_-2020_10_05_00_27_36.report.json#performance">
+                Performance <strong>45</strong>
+              </a>
 
-            
-            
+              
+              
+              <svg class="u-fill-red cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>95</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_economic_impact_payment_prepaid_card_-2020_10_05_00_27_36.report.json#accessibility">
+                Accessibility <strong>95</strong>
+              </a>
 
-            <strong>92</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_economic_impact_payment_prepaid_card_-2020_10_05_00_27_36.report.json#best-practices">
+                Best practices <strong>92</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>52</strong> Pwa
-          </li>
+              
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_economic_impact_payment_prepaid_card_-2020_10_05_00_27_36.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_economic_impact_payment_prepaid_card_-2020_10_05_00_27_36.report.json">
+            View full desktop report
+          </a>
+        </div>
+
       </td>
       
       <td>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_economic_impact_payment_prepaid_card_-2020_10_05_00_43_44.report.json"
-          >
-            View mobile report
-          </a>
-        </div>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_economic_impact_payment_prepaid_card_-2020_10_05_00_27_36.report.json"
-          >
-            View desktop report
-          </a>
-        </div>
-        
+        <a class="report-link"
+           href="#">
+          View report history
+          (coming soon)
+        </a>
       </td>
     </tr>
     
@@ -614,186 +784,240 @@
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+                
+              
 
-            <strong>95</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_guide_covid_19_economic_stimulus_checks_-2020_10_05_00_43_58.report.json#performance">
+                Performance <strong>95</strong>
+              </a>
 
-            
-            
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>97</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+                
+              
 
-            
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_guide_covid_19_economic_stimulus_checks_-2020_10_05_00_43_58.report.json#accessibility">
+                Accessibility <strong>97</strong>
+              </a>
 
-            <strong>85</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_guide_covid_19_economic_stimulus_checks_-2020_10_05_00_43_58.report.json#best-practices">
+                Best practices <strong>85</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>54</strong> Pwa
-          </li>
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_guide_covid_19_economic_stimulus_checks_-2020_10_05_00_43_58.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_guide_covid_19_economic_stimulus_checks_-2020_10_05_00_43_58.report.json">
+            View full mobile report
+          </a>
+        </div>
+
       </td>
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
+            <li class="m-list_item">
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
 
-            
-            
+              
+                
+              
 
-            <strong>69</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_guide_covid_19_economic_stimulus_checks_-2020_10_05_00_27_50.report.json#performance">
+                Performance <strong>69</strong>
+              </a>
 
-            
-            
+              
+              
 
-            
-            
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>97</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_guide_covid_19_economic_stimulus_checks_-2020_10_05_00_27_50.report.json#accessibility">
+                Accessibility <strong>97</strong>
+              </a>
 
-            <strong>92</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_guide_covid_19_economic_stimulus_checks_-2020_10_05_00_27_50.report.json#best-practices">
+                Best practices <strong>92</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>52</strong> Pwa
-          </li>
+              
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_guide_covid_19_economic_stimulus_checks_-2020_10_05_00_27_50.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_guide_covid_19_economic_stimulus_checks_-2020_10_05_00_27_50.report.json">
+            View full desktop report
+          </a>
+        </div>
+
       </td>
       
       <td>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_guide_covid_19_economic_stimulus_checks_-2020_10_05_00_43_58.report.json"
-          >
-            View mobile report
-          </a>
-        </div>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_guide_covid_19_economic_stimulus_checks_-2020_10_05_00_27_50.report.json"
-          >
-            View desktop report
-          </a>
-        </div>
-        
+        <a class="report-link"
+           href="#">
+          View report history
+          (coming soon)
+        </a>
       </td>
     </tr>
     
@@ -805,186 +1029,242 @@
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
+            <li class="m-list_item">
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
 
-            
-            
+              
+                
+              
 
-            <strong>69</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_protect_yourself_financially_from_impact_of_coronavirus_-2020_10_05_00_45_06.report.json#performance">
+                Performance <strong>69</strong>
+              </a>
 
-            
-            
+              
+              
 
-            
-            
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>95</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+                
+              
 
-            
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_protect_yourself_financially_from_impact_of_coronavirus_-2020_10_05_00_45_06.report.json#accessibility">
+                Accessibility <strong>95</strong>
+              </a>
 
-            <strong>85</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
-            <svg class="u-fill-red cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
-            
+              
+                
+              
 
-            
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_protect_yourself_financially_from_impact_of_coronavirus_-2020_10_05_00_45_06.report.json#best-practices">
+                Best practices <strong>85</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>29</strong> Pwa
-          </li>
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_protect_yourself_financially_from_impact_of_coronavirus_-2020_10_05_00_45_06.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_protect_yourself_financially_from_impact_of_coronavirus_-2020_10_05_00_45_06.report.json">
+            View full mobile report
+          </a>
+        </div>
+
       </td>
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
-            <svg class="u-fill-red cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
+              
+                
+              
 
-            <strong>44</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_protect_yourself_financially_from_impact_of_coronavirus_-2020_10_05_00_28_57.report.json#performance">
+                Performance <strong>44</strong>
+              </a>
 
-            
-            
+              
+              
+              <svg class="u-fill-red cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>95</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_protect_yourself_financially_from_impact_of_coronavirus_-2020_10_05_00_28_57.report.json#accessibility">
+                Accessibility <strong>95</strong>
+              </a>
 
-            <strong>92</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_protect_yourself_financially_from_impact_of_coronavirus_-2020_10_05_00_28_57.report.json#best-practices">
+                Best practices <strong>92</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>52</strong> Pwa
-          </li>
+              
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_protect_yourself_financially_from_impact_of_coronavirus_-2020_10_05_00_28_57.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_protect_yourself_financially_from_impact_of_coronavirus_-2020_10_05_00_28_57.report.json">
+            View full desktop report
+          </a>
+        </div>
+
       </td>
       
       <td>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_protect_yourself_financially_from_impact_of_coronavirus_-2020_10_05_00_45_06.report.json"
-          >
-            View mobile report
-          </a>
-        </div>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_blog_protect_yourself_financially_from_impact_of_coronavirus_-2020_10_05_00_28_57.report.json"
-          >
-            View desktop report
-          </a>
-        </div>
-        
+        <a class="report-link"
+           href="#">
+          View report history
+          (coming soon)
+        </a>
       </td>
     </tr>
     
@@ -996,186 +1276,240 @@
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+                
+              
 
-            <strong>91</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_contact_us_-2020_10_05_00_45_33.report.json#performance">
+                Performance <strong>91</strong>
+              </a>
 
-            
-            
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>97</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+                
+              
 
-            
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_contact_us_-2020_10_05_00_45_33.report.json#accessibility">
+                Accessibility <strong>97</strong>
+              </a>
 
-            <strong>85</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>99</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_contact_us_-2020_10_05_00_45_33.report.json#best-practices">
+                Best practices <strong>85</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>54</strong> Pwa
-          </li>
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_contact_us_-2020_10_05_00_45_33.report.json#seo">
+                SEO <strong>99</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_contact_us_-2020_10_05_00_45_33.report.json">
+            View full mobile report
+          </a>
+        </div>
+
       </td>
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
+            <li class="m-list_item">
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
 
-            
-            
+              
+                
+              
 
-            <strong>64</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_contact_us_-2020_10_05_00_29_25.report.json#performance">
+                Performance <strong>64</strong>
+              </a>
 
-            
-            
+              
+              
 
-            
-            
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>97</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_contact_us_-2020_10_05_00_29_25.report.json#accessibility">
+                Accessibility <strong>97</strong>
+              </a>
 
-            <strong>92</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_contact_us_-2020_10_05_00_29_25.report.json#best-practices">
+                Best practices <strong>92</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>52</strong> Pwa
-          </li>
+              
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_contact_us_-2020_10_05_00_29_25.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_contact_us_-2020_10_05_00_29_25.report.json">
+            View full desktop report
+          </a>
+        </div>
+
       </td>
       
       <td>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_contact_us_-2020_10_05_00_45_33.report.json"
-          >
-            View mobile report
-          </a>
-        </div>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_about_us_contact_us_-2020_10_05_00_29_25.report.json"
-          >
-            View desktop report
-          </a>
-        </div>
-        
+        <a class="report-link"
+           href="#">
+          View report history
+          (coming soon)
+        </a>
       </td>
     </tr>
     
@@ -1187,186 +1521,240 @@
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+                
+              
 
-            <strong>91</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_-2020_10_05_00_46_23.report.json#performance">
+                Performance <strong>91</strong>
+              </a>
 
-            
-            
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>98</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+                
+              
 
-            
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_-2020_10_05_00_46_23.report.json#accessibility">
+                Accessibility <strong>98</strong>
+              </a>
 
-            <strong>85</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_-2020_10_05_00_46_23.report.json#best-practices">
+                Best practices <strong>85</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>54</strong> Pwa
-          </li>
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_-2020_10_05_00_46_23.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_-2020_10_05_00_46_23.report.json">
+            View full mobile report
+          </a>
+        </div>
+
       </td>
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
+            <li class="m-list_item">
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
 
-            
-            
+              
+                
+              
 
-            <strong>56</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_-2020_10_05_00_29_51.report.json#performance">
+                Performance <strong>56</strong>
+              </a>
 
-            
-            
+              
+              
 
-            
-            
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>98</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_-2020_10_05_00_29_51.report.json#accessibility">
+                Accessibility <strong>98</strong>
+              </a>
 
-            <strong>92</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_-2020_10_05_00_29_51.report.json#best-practices">
+                Best practices <strong>92</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>52</strong> Pwa
-          </li>
+              
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_-2020_10_05_00_29_51.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_-2020_10_05_00_29_51.report.json">
+            View full desktop report
+          </a>
+        </div>
+
       </td>
       
       <td>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_-2020_10_05_00_46_23.report.json"
-          >
-            View mobile report
-          </a>
-        </div>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_-2020_10_05_00_29_51.report.json"
-          >
-            View desktop report
-          </a>
-        </div>
-        
+        <a class="report-link"
+           href="#">
+          View report history
+          (coming soon)
+        </a>
       </td>
     </tr>
     
@@ -1378,186 +1766,240 @@
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+                
+              
 
-            <strong>92</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_how_can_i_tell_who_owns_my_mortgage_en_214_-2020_10_05_00_46_35.report.json#performance">
+                Performance <strong>92</strong>
+              </a>
 
-            
-            
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>96</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+                
+              
 
-            
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_how_can_i_tell_who_owns_my_mortgage_en_214_-2020_10_05_00_46_35.report.json#accessibility">
+                Accessibility <strong>96</strong>
+              </a>
 
-            <strong>85</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_how_can_i_tell_who_owns_my_mortgage_en_214_-2020_10_05_00_46_35.report.json#best-practices">
+                Best practices <strong>85</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>54</strong> Pwa
-          </li>
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_how_can_i_tell_who_owns_my_mortgage_en_214_-2020_10_05_00_46_35.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_how_can_i_tell_who_owns_my_mortgage_en_214_-2020_10_05_00_46_35.report.json">
+            View full mobile report
+          </a>
+        </div>
+
       </td>
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
+            <li class="m-list_item">
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
 
-            
-            
+              
+                
+              
 
-            <strong>56</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_how_can_i_tell_who_owns_my_mortgage_en_214_-2020_10_05_00_30_43.report.json#performance">
+                Performance <strong>56</strong>
+              </a>
 
-            
-            
+              
+              
 
-            
-            
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>96</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_how_can_i_tell_who_owns_my_mortgage_en_214_-2020_10_05_00_30_43.report.json#accessibility">
+                Accessibility <strong>96</strong>
+              </a>
 
-            <strong>92</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_how_can_i_tell_who_owns_my_mortgage_en_214_-2020_10_05_00_30_43.report.json#best-practices">
+                Best practices <strong>92</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>52</strong> Pwa
-          </li>
+              
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_how_can_i_tell_who_owns_my_mortgage_en_214_-2020_10_05_00_30_43.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_how_can_i_tell_who_owns_my_mortgage_en_214_-2020_10_05_00_30_43.report.json">
+            View full desktop report
+          </a>
+        </div>
+
       </td>
       
       <td>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_how_can_i_tell_who_owns_my_mortgage_en_214_-2020_10_05_00_46_35.report.json"
-          >
-            View mobile report
-          </a>
-        </div>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_how_can_i_tell_who_owns_my_mortgage_en_214_-2020_10_05_00_30_43.report.json"
-          >
-            View desktop report
-          </a>
-        </div>
-        
+        <a class="report-link"
+           href="#">
+          View report history
+          (coming soon)
+        </a>
       </td>
     </tr>
     
@@ -1569,186 +2011,242 @@
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
+            <li class="m-list_item">
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
 
-            
-            
+              
+                
+              
 
-            <strong>72</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_is_a_debt_to_income_ratio_why_is_the_43_debt_to_income_ratio_important_en_1791_-2020_10_05_00_48_01.report.json#performance">
+                Performance <strong>72</strong>
+              </a>
 
-            
-            
+              
+              
 
-            
-            
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>95</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+                
+              
 
-            
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_is_a_debt_to_income_ratio_why_is_the_43_debt_to_income_ratio_important_en_1791_-2020_10_05_00_48_01.report.json#accessibility">
+                Accessibility <strong>95</strong>
+              </a>
 
-            <strong>85</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
-            <svg class="u-fill-red cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
-            
+              
+                
+              
 
-            
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_is_a_debt_to_income_ratio_why_is_the_43_debt_to_income_ratio_important_en_1791_-2020_10_05_00_48_01.report.json#best-practices">
+                Best practices <strong>85</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>29</strong> Pwa
-          </li>
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_is_a_debt_to_income_ratio_why_is_the_43_debt_to_income_ratio_important_en_1791_-2020_10_05_00_48_01.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_is_a_debt_to_income_ratio_why_is_the_43_debt_to_income_ratio_important_en_1791_-2020_10_05_00_48_01.report.json">
+            View full mobile report
+          </a>
+        </div>
+
       </td>
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
-            <svg class="u-fill-red cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
+              
+                
+              
 
-            <strong>39</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_is_a_debt_to_income_ratio_why_is_the_43_debt_to_income_ratio_important_en_1791_-2020_10_05_00_31_40.report.json#performance">
+                Performance <strong>39</strong>
+              </a>
 
-            
-            
+              
+              
+              <svg class="u-fill-red cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>95</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_is_a_debt_to_income_ratio_why_is_the_43_debt_to_income_ratio_important_en_1791_-2020_10_05_00_31_40.report.json#accessibility">
+                Accessibility <strong>95</strong>
+              </a>
 
-            <strong>92</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
-            <svg class="u-fill-red cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
-            
+              
+                
+              
 
-            
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_is_a_debt_to_income_ratio_why_is_the_43_debt_to_income_ratio_important_en_1791_-2020_10_05_00_31_40.report.json#best-practices">
+                Best practices <strong>92</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>26</strong> Pwa
-          </li>
+              
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_is_a_debt_to_income_ratio_why_is_the_43_debt_to_income_ratio_important_en_1791_-2020_10_05_00_31_40.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_is_a_debt_to_income_ratio_why_is_the_43_debt_to_income_ratio_important_en_1791_-2020_10_05_00_31_40.report.json">
+            View full desktop report
+          </a>
+        </div>
+
       </td>
       
       <td>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_is_a_debt_to_income_ratio_why_is_the_43_debt_to_income_ratio_important_en_1791_-2020_10_05_00_48_01.report.json"
-          >
-            View mobile report
-          </a>
-        </div>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_is_a_debt_to_income_ratio_why_is_the_43_debt_to_income_ratio_important_en_1791_-2020_10_05_00_31_40.report.json"
-          >
-            View desktop report
-          </a>
-        </div>
-        
+        <a class="report-link"
+           href="#">
+          View report history
+          (coming soon)
+        </a>
       </td>
     </tr>
     
@@ -1760,186 +2258,242 @@
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
+            <li class="m-list_item">
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
 
-            
-            
+              
+                
+              
 
-            <strong>74</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_is_forbearance_en_289_-2020_10_05_00_48_37.report.json#performance">
+                Performance <strong>74</strong>
+              </a>
 
-            
-            
+              
+              
 
-            
-            
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>93</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+                
+              
 
-            
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_is_forbearance_en_289_-2020_10_05_00_48_37.report.json#accessibility">
+                Accessibility <strong>93</strong>
+              </a>
 
-            <strong>85</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_is_forbearance_en_289_-2020_10_05_00_48_37.report.json#best-practices">
+                Best practices <strong>85</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>54</strong> Pwa
-          </li>
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_is_forbearance_en_289_-2020_10_05_00_48_37.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_is_forbearance_en_289_-2020_10_05_00_48_37.report.json">
+            View full mobile report
+          </a>
+        </div>
+
       </td>
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
-            <svg class="u-fill-red cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
+              
+                
+              
 
-            <strong>19</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_is_forbearance_en_289_-2020_10_05_00_32_28.report.json#performance">
+                Performance <strong>19</strong>
+              </a>
 
-            
-            
+              
+              
+              <svg class="u-fill-red cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>93</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_is_forbearance_en_289_-2020_10_05_00_32_28.report.json#accessibility">
+                Accessibility <strong>93</strong>
+              </a>
 
-            <strong>92</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
-            <svg class="u-fill-red cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
-            
+              
+                
+              
 
-            
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_is_forbearance_en_289_-2020_10_05_00_32_28.report.json#best-practices">
+                Best practices <strong>92</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>26</strong> Pwa
-          </li>
+              
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_is_forbearance_en_289_-2020_10_05_00_32_28.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_is_forbearance_en_289_-2020_10_05_00_32_28.report.json">
+            View full desktop report
+          </a>
+        </div>
+
       </td>
       
       <td>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_is_forbearance_en_289_-2020_10_05_00_48_37.report.json"
-          >
-            View mobile report
-          </a>
-        </div>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_is_forbearance_en_289_-2020_10_05_00_32_28.report.json"
-          >
-            View desktop report
-          </a>
-        </div>
-        
+        <a class="report-link"
+           href="#">
+          View report history
+          (coming soon)
+        </a>
       </td>
     </tr>
     
@@ -1951,186 +2505,242 @@
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
+            <li class="m-list_item">
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
 
-            
-            
+              
+                
+              
 
-            <strong>60</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_is_the_best_way_to_negotiate_a_settlement_with_a_debt_collector_en_1447_-2020_10_05_00_49_43.report.json#performance">
+                Performance <strong>60</strong>
+              </a>
 
-            
-            
+              
+              
 
-            
-            
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>95</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+                
+              
 
-            
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_is_the_best_way_to_negotiate_a_settlement_with_a_debt_collector_en_1447_-2020_10_05_00_49_43.report.json#accessibility">
+                Accessibility <strong>95</strong>
+              </a>
 
-            <strong>85</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>92</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_is_the_best_way_to_negotiate_a_settlement_with_a_debt_collector_en_1447_-2020_10_05_00_49_43.report.json#best-practices">
+                Best practices <strong>85</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>54</strong> Pwa
-          </li>
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_is_the_best_way_to_negotiate_a_settlement_with_a_debt_collector_en_1447_-2020_10_05_00_49_43.report.json#seo">
+                SEO <strong>92</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_is_the_best_way_to_negotiate_a_settlement_with_a_debt_collector_en_1447_-2020_10_05_00_49_43.report.json">
+            View full mobile report
+          </a>
+        </div>
+
       </td>
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
-            <svg class="u-fill-red cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
+              
+                
+              
 
-            <strong>38</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_is_the_best_way_to_negotiate_a_settlement_with_a_debt_collector_en_1447_-2020_10_05_00_33_16.report.json#performance">
+                Performance <strong>38</strong>
+              </a>
 
-            
-            
+              
+              
+              <svg class="u-fill-red cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>95</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_is_the_best_way_to_negotiate_a_settlement_with_a_debt_collector_en_1447_-2020_10_05_00_33_16.report.json#accessibility">
+                Accessibility <strong>95</strong>
+              </a>
 
-            <strong>92</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>91</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
-            <svg class="u-fill-red cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
-            
+              
+                
+              
 
-            
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_is_the_best_way_to_negotiate_a_settlement_with_a_debt_collector_en_1447_-2020_10_05_00_33_16.report.json#best-practices">
+                Best practices <strong>92</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>26</strong> Pwa
-          </li>
+              
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_is_the_best_way_to_negotiate_a_settlement_with_a_debt_collector_en_1447_-2020_10_05_00_33_16.report.json#seo">
+                SEO <strong>91</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_is_the_best_way_to_negotiate_a_settlement_with_a_debt_collector_en_1447_-2020_10_05_00_33_16.report.json">
+            View full desktop report
+          </a>
+        </div>
+
       </td>
       
       <td>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_is_the_best_way_to_negotiate_a_settlement_with_a_debt_collector_en_1447_-2020_10_05_00_49_43.report.json"
-          >
-            View mobile report
-          </a>
-        </div>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_is_the_best_way_to_negotiate_a_settlement_with_a_debt_collector_en_1447_-2020_10_05_00_33_16.report.json"
-          >
-            View desktop report
-          </a>
-        </div>
-        
+        <a class="report-link"
+           href="#">
+          View report history
+          (coming soon)
+        </a>
       </td>
     </tr>
     
@@ -2142,186 +2752,240 @@
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+                
+              
 
-            <strong>94</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_should_i_do_when_a_debt_collector_contacts_me_en_1695_-2020_10_05_00_50_32.report.json#performance">
+                Performance <strong>94</strong>
+              </a>
 
-            
-            
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>95</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+                
+              
 
-            
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_should_i_do_when_a_debt_collector_contacts_me_en_1695_-2020_10_05_00_50_32.report.json#accessibility">
+                Accessibility <strong>95</strong>
+              </a>
 
-            <strong>85</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_should_i_do_when_a_debt_collector_contacts_me_en_1695_-2020_10_05_00_50_32.report.json#best-practices">
+                Best practices <strong>85</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>54</strong> Pwa
-          </li>
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_should_i_do_when_a_debt_collector_contacts_me_en_1695_-2020_10_05_00_50_32.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_should_i_do_when_a_debt_collector_contacts_me_en_1695_-2020_10_05_00_50_32.report.json">
+            View full mobile report
+          </a>
+        </div>
+
       </td>
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
+            <li class="m-list_item">
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
 
-            
-            
+              
+                
+              
 
-            <strong>54</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_should_i_do_when_a_debt_collector_contacts_me_en_1695_-2020_10_05_00_33_45.report.json#performance">
+                Performance <strong>54</strong>
+              </a>
 
-            
-            
+              
+              
 
-            
-            
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>95</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_should_i_do_when_a_debt_collector_contacts_me_en_1695_-2020_10_05_00_33_45.report.json#accessibility">
+                Accessibility <strong>95</strong>
+              </a>
 
-            <strong>92</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_should_i_do_when_a_debt_collector_contacts_me_en_1695_-2020_10_05_00_33_45.report.json#best-practices">
+                Best practices <strong>92</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>52</strong> Pwa
-          </li>
+              
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_should_i_do_when_a_debt_collector_contacts_me_en_1695_-2020_10_05_00_33_45.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_should_i_do_when_a_debt_collector_contacts_me_en_1695_-2020_10_05_00_33_45.report.json">
+            View full desktop report
+          </a>
+        </div>
+
       </td>
       
       <td>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_should_i_do_when_a_debt_collector_contacts_me_en_1695_-2020_10_05_00_50_32.report.json"
-          >
-            View mobile report
-          </a>
-        </div>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_ask_cfpb_what_should_i_do_when_a_debt_collector_contacts_me_en_1695_-2020_10_05_00_33_45.report.json"
-          >
-            View desktop report
-          </a>
-        </div>
-        
+        <a class="report-link"
+           href="#">
+          View report history
+          (coming soon)
+        </a>
       </td>
     </tr>
     
@@ -2333,186 +2997,240 @@
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+                
+              
 
-            <strong>92</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_complaint_-2020_10_05_00_50_45.report.json#performance">
+                Performance <strong>92</strong>
+              </a>
 
-            
-            
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>91</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+                
+              
 
-            
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_complaint_-2020_10_05_00_50_45.report.json#accessibility">
+                Accessibility <strong>91</strong>
+              </a>
 
-            <strong>85</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_complaint_-2020_10_05_00_50_45.report.json#best-practices">
+                Best practices <strong>85</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>54</strong> Pwa
-          </li>
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_complaint_-2020_10_05_00_50_45.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_complaint_-2020_10_05_00_50_45.report.json">
+            View full mobile report
+          </a>
+        </div>
+
       </td>
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
+            <li class="m-list_item">
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
 
-            
-            
+              
+                
+              
 
-            <strong>62</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_complaint_-2020_10_05_00_34_26.report.json#performance">
+                Performance <strong>62</strong>
+              </a>
 
-            
-            
+              
+              
 
-            
-            
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>91</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_complaint_-2020_10_05_00_34_26.report.json#accessibility">
+                Accessibility <strong>91</strong>
+              </a>
 
-            <strong>92</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_complaint_-2020_10_05_00_34_26.report.json#best-practices">
+                Best practices <strong>92</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>52</strong> Pwa
-          </li>
+              
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_complaint_-2020_10_05_00_34_26.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_complaint_-2020_10_05_00_34_26.report.json">
+            View full desktop report
+          </a>
+        </div>
+
       </td>
       
       <td>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_complaint_-2020_10_05_00_50_45.report.json"
-          >
-            View mobile report
-          </a>
-        </div>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_complaint_-2020_10_05_00_34_26.report.json"
-          >
-            View desktop report
-          </a>
-        </div>
-        
+        <a class="report-link"
+           href="#">
+          View report history
+          (coming soon)
+        </a>
       </td>
     </tr>
     
@@ -2524,186 +3242,240 @@
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+                
+              
 
-            <strong>95</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_complaint_getting_started_-2020_10_05_00_51_46.report.json#performance">
+                Performance <strong>95</strong>
+              </a>
 
-            
-            
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>98</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+                
+              
 
-            
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_complaint_getting_started_-2020_10_05_00_51_46.report.json#accessibility">
+                Accessibility <strong>98</strong>
+              </a>
 
-            <strong>85</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_complaint_getting_started_-2020_10_05_00_51_46.report.json#best-practices">
+                Best practices <strong>85</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>54</strong> Pwa
-          </li>
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_complaint_getting_started_-2020_10_05_00_51_46.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_complaint_getting_started_-2020_10_05_00_51_46.report.json">
+            View full mobile report
+          </a>
+        </div>
+
       </td>
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
+            <li class="m-list_item">
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
 
-            
-            
+              
+                
+              
 
-            <strong>69</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_complaint_getting_started_-2020_10_05_00_34_50.report.json#performance">
+                Performance <strong>69</strong>
+              </a>
 
-            
-            
+              
+              
 
-            
-            
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>98</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_complaint_getting_started_-2020_10_05_00_34_50.report.json#accessibility">
+                Accessibility <strong>98</strong>
+              </a>
 
-            <strong>92</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_complaint_getting_started_-2020_10_05_00_34_50.report.json#best-practices">
+                Best practices <strong>92</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>52</strong> Pwa
-          </li>
+              
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_complaint_getting_started_-2020_10_05_00_34_50.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_complaint_getting_started_-2020_10_05_00_34_50.report.json">
+            View full desktop report
+          </a>
+        </div>
+
       </td>
       
       <td>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_complaint_getting_started_-2020_10_05_00_51_46.report.json"
-          >
-            View mobile report
-          </a>
-        </div>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_complaint_getting_started_-2020_10_05_00_34_50.report.json"
-          >
-            View desktop report
-          </a>
-        </div>
-        
+        <a class="report-link"
+           href="#">
+          View report history
+          (coming soon)
+        </a>
       </td>
     </tr>
     
@@ -2715,186 +3487,242 @@
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
+            <li class="m-list_item">
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
 
-            
-            
+              
+                
+              
 
-            <strong>81</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_consumer_tools_prepaid_cards_-2020_10_05_00_52_11.report.json#performance">
+                Performance <strong>81</strong>
+              </a>
 
-            
-            
+              
+              
 
-            
-            
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>98</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+                
+              
 
-            
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_consumer_tools_prepaid_cards_-2020_10_05_00_52_11.report.json#accessibility">
+                Accessibility <strong>98</strong>
+              </a>
 
-            <strong>85</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>92</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_consumer_tools_prepaid_cards_-2020_10_05_00_52_11.report.json#best-practices">
+                Best practices <strong>85</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>54</strong> Pwa
-          </li>
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_consumer_tools_prepaid_cards_-2020_10_05_00_52_11.report.json#seo">
+                SEO <strong>92</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_consumer_tools_prepaid_cards_-2020_10_05_00_52_11.report.json">
+            View full mobile report
+          </a>
+        </div>
+
       </td>
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
-            <svg class="u-fill-red cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
+              
+                
+              
 
-            <strong>45</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_consumer_tools_prepaid_cards_-2020_10_05_00_35_51.report.json#performance">
+                Performance <strong>45</strong>
+              </a>
 
-            
-            
+              
+              
+              <svg class="u-fill-red cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>98</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_consumer_tools_prepaid_cards_-2020_10_05_00_35_51.report.json#accessibility">
+                Accessibility <strong>98</strong>
+              </a>
 
-            <strong>92</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>91</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_consumer_tools_prepaid_cards_-2020_10_05_00_35_51.report.json#best-practices">
+                Best practices <strong>92</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>52</strong> Pwa
-          </li>
+              
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_consumer_tools_prepaid_cards_-2020_10_05_00_35_51.report.json#seo">
+                SEO <strong>91</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_consumer_tools_prepaid_cards_-2020_10_05_00_35_51.report.json">
+            View full desktop report
+          </a>
+        </div>
+
       </td>
       
       <td>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_consumer_tools_prepaid_cards_-2020_10_05_00_52_11.report.json"
-          >
-            View mobile report
-          </a>
-        </div>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_consumer_tools_prepaid_cards_-2020_10_05_00_35_51.report.json"
-          >
-            View desktop report
-          </a>
-        </div>
-        
+        <a class="report-link"
+           href="#">
+          View report history
+          (coming soon)
+        </a>
       </td>
     </tr>
     
@@ -2906,186 +3734,240 @@
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+                
+              
 
-            <strong>92</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_-2020_10_05_00_52_49.report.json#performance">
+                Performance <strong>92</strong>
+              </a>
 
-            
-            
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>95</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+                
+              
 
-            
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_-2020_10_05_00_52_49.report.json#accessibility">
+                Accessibility <strong>95</strong>
+              </a>
 
-            <strong>85</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_-2020_10_05_00_52_49.report.json#best-practices">
+                Best practices <strong>85</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>54</strong> Pwa
-          </li>
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_-2020_10_05_00_52_49.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_-2020_10_05_00_52_49.report.json">
+            View full mobile report
+          </a>
+        </div>
+
       </td>
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
+            <li class="m-list_item">
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
 
-            
-            
+              
+                
+              
 
-            <strong>54</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_-2020_10_05_00_36_16.report.json#performance">
+                Performance <strong>54</strong>
+              </a>
 
-            
-            
+              
+              
 
-            
-            
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>95</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_-2020_10_05_00_36_16.report.json#accessibility">
+                Accessibility <strong>95</strong>
+              </a>
 
-            <strong>92</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_-2020_10_05_00_36_16.report.json#best-practices">
+                Best practices <strong>92</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>52</strong> Pwa
-          </li>
+              
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_-2020_10_05_00_36_16.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_-2020_10_05_00_36_16.report.json">
+            View full desktop report
+          </a>
+        </div>
+
       </td>
       
       <td>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_-2020_10_05_00_52_49.report.json"
-          >
-            View mobile report
-          </a>
-        </div>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_-2020_10_05_00_36_16.report.json"
-          >
-            View desktop report
-          </a>
-        </div>
-        
+        <a class="report-link"
+           href="#">
+          View report history
+          (coming soon)
+        </a>
       </td>
     </tr>
     
@@ -3097,186 +3979,242 @@
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
-            <svg class="u-fill-red cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
+              
+                
+              
 
-            <strong>44</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_managing_your_finances_economic_impact_payment_prepaid_debit_cards_-2020_10_05_00_53_14.report.json#performance">
+                Performance <strong>44</strong>
+              </a>
 
-            
-            
+              
+              
+              <svg class="u-fill-red cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>95</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+                
+              
 
-            
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_managing_your_finances_economic_impact_payment_prepaid_debit_cards_-2020_10_05_00_53_14.report.json#accessibility">
+                Accessibility <strong>95</strong>
+              </a>
 
-            <strong>85</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_managing_your_finances_economic_impact_payment_prepaid_debit_cards_-2020_10_05_00_53_14.report.json#best-practices">
+                Best practices <strong>85</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>54</strong> Pwa
-          </li>
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_managing_your_finances_economic_impact_payment_prepaid_debit_cards_-2020_10_05_00_53_14.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_managing_your_finances_economic_impact_payment_prepaid_debit_cards_-2020_10_05_00_53_14.report.json">
+            View full mobile report
+          </a>
+        </div>
+
       </td>
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
-            <svg class="u-fill-red cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
+              
+                
+              
 
-            <strong>28</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_managing_your_finances_economic_impact_payment_prepaid_debit_cards_-2020_10_05_00_37_09.report.json#performance">
+                Performance <strong>28</strong>
+              </a>
 
-            
-            
+              
+              
+              <svg class="u-fill-red cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>95</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_managing_your_finances_economic_impact_payment_prepaid_debit_cards_-2020_10_05_00_37_09.report.json#accessibility">
+                Accessibility <strong>95</strong>
+              </a>
 
-            <strong>92</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_managing_your_finances_economic_impact_payment_prepaid_debit_cards_-2020_10_05_00_37_09.report.json#best-practices">
+                Best practices <strong>92</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>52</strong> Pwa
-          </li>
+              
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_managing_your_finances_economic_impact_payment_prepaid_debit_cards_-2020_10_05_00_37_09.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_managing_your_finances_economic_impact_payment_prepaid_debit_cards_-2020_10_05_00_37_09.report.json">
+            View full desktop report
+          </a>
+        </div>
+
       </td>
       
       <td>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_managing_your_finances_economic_impact_payment_prepaid_debit_cards_-2020_10_05_00_53_14.report.json"
-          >
-            View mobile report
-          </a>
-        </div>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_managing_your_finances_economic_impact_payment_prepaid_debit_cards_-2020_10_05_00_37_09.report.json"
-          >
-            View desktop report
-          </a>
-        </div>
-        
+        <a class="report-link"
+           href="#">
+          View report history
+          (coming soon)
+        </a>
       </td>
     </tr>
     
@@ -3288,186 +4226,242 @@
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
-            <svg class="u-fill-red cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
+              
+                
+              
 
-            <strong>47</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_mortgage_and_housing_assistance_-2020_10_05_00_54_12.report.json#performance">
+                Performance <strong>47</strong>
+              </a>
 
-            
-            
+              
+              
+              <svg class="u-fill-red cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>95</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+                
+              
 
-            
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_mortgage_and_housing_assistance_-2020_10_05_00_54_12.report.json#accessibility">
+                Accessibility <strong>95</strong>
+              </a>
 
-            <strong>85</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
-            <svg class="u-fill-red cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
-            
+              
+                
+              
 
-            
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_mortgage_and_housing_assistance_-2020_10_05_00_54_12.report.json#best-practices">
+                Best practices <strong>85</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>29</strong> Pwa
-          </li>
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_mortgage_and_housing_assistance_-2020_10_05_00_54_12.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_mortgage_and_housing_assistance_-2020_10_05_00_54_12.report.json">
+            View full mobile report
+          </a>
+        </div>
+
       </td>
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
-            <svg class="u-fill-red cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
+              
+                
+              
 
-            <strong>30</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_mortgage_and_housing_assistance_-2020_10_05_00_37_37.report.json#performance">
+                Performance <strong>30</strong>
+              </a>
 
-            
-            
+              
+              
+              <svg class="u-fill-red cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>95</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_mortgage_and_housing_assistance_-2020_10_05_00_37_37.report.json#accessibility">
+                Accessibility <strong>95</strong>
+              </a>
 
-            <strong>92</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_mortgage_and_housing_assistance_-2020_10_05_00_37_37.report.json#best-practices">
+                Best practices <strong>92</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>52</strong> Pwa
-          </li>
+              
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_mortgage_and_housing_assistance_-2020_10_05_00_37_37.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_mortgage_and_housing_assistance_-2020_10_05_00_37_37.report.json">
+            View full desktop report
+          </a>
+        </div>
+
       </td>
       
       <td>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_mortgage_and_housing_assistance_-2020_10_05_00_54_12.report.json"
-          >
-            View mobile report
-          </a>
-        </div>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_mortgage_and_housing_assistance_-2020_10_05_00_37_37.report.json"
-          >
-            View desktop report
-          </a>
-        </div>
-        
+        <a class="report-link"
+           href="#">
+          View report history
+          (coming soon)
+        </a>
       </td>
     </tr>
     
@@ -3479,186 +4473,240 @@
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+                
+              
 
-            <strong>95</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_student_loans_-2020_10_05_00_54_52.report.json#performance">
+                Performance <strong>95</strong>
+              </a>
 
-            
-            
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>97</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+                
+              
 
-            
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_student_loans_-2020_10_05_00_54_52.report.json#accessibility">
+                Accessibility <strong>97</strong>
+              </a>
 
-            <strong>85</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_student_loans_-2020_10_05_00_54_52.report.json#best-practices">
+                Best practices <strong>85</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>54</strong> Pwa
-          </li>
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_student_loans_-2020_10_05_00_54_52.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_student_loans_-2020_10_05_00_54_52.report.json">
+            View full mobile report
+          </a>
+        </div>
+
       </td>
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
+            <li class="m-list_item">
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
 
-            
-            
+              
+                
+              
 
-            <strong>70</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_student_loans_-2020_10_05_00_38_29.report.json#performance">
+                Performance <strong>70</strong>
+              </a>
 
-            
-            
+              
+              
 
-            
-            
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>97</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_student_loans_-2020_10_05_00_38_29.report.json#accessibility">
+                Accessibility <strong>97</strong>
+              </a>
 
-            <strong>92</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_student_loans_-2020_10_05_00_38_29.report.json#best-practices">
+                Best practices <strong>92</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>52</strong> Pwa
-          </li>
+              
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_student_loans_-2020_10_05_00_38_29.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_student_loans_-2020_10_05_00_38_29.report.json">
+            View full desktop report
+          </a>
+        </div>
+
       </td>
       
       <td>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_student_loans_-2020_10_05_00_54_52.report.json"
-          >
-            View mobile report
-          </a>
-        </div>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_coronavirus_student_loans_-2020_10_05_00_38_29.report.json"
-          >
-            View desktop report
-          </a>
-        </div>
-        
+        <a class="report-link"
+           href="#">
+          View report history
+          (coming soon)
+        </a>
       </td>
     </tr>
     
@@ -3670,186 +4718,242 @@
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+                
+              
 
-            <strong>90</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_find_a_housing_counselor_-2020_10_05_00_55_16.report.json#performance">
+                Performance <strong>90</strong>
+              </a>
 
-            
-            
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>98</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+                
+              
 
-            
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_find_a_housing_counselor_-2020_10_05_00_55_16.report.json#accessibility">
+                Accessibility <strong>98</strong>
+              </a>
 
-            <strong>77</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_find_a_housing_counselor_-2020_10_05_00_55_16.report.json#best-practices">
+                Best practices <strong>77</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>54</strong> Pwa
-          </li>
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_find_a_housing_counselor_-2020_10_05_00_55_16.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_find_a_housing_counselor_-2020_10_05_00_55_16.report.json">
+            View full mobile report
+          </a>
+        </div>
+
       </td>
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
+            <li class="m-list_item">
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
 
-            
-            
+              
+                
+              
 
-            <strong>59</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_find_a_housing_counselor_-2020_10_05_00_38_53.report.json#performance">
+                Performance <strong>59</strong>
+              </a>
 
-            
-            
+              
+              
 
-            
-            
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>98</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+                
+              
 
-            
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_find_a_housing_counselor_-2020_10_05_00_38_53.report.json#accessibility">
+                Accessibility <strong>98</strong>
+              </a>
 
-            <strong>85</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_find_a_housing_counselor_-2020_10_05_00_38_53.report.json#best-practices">
+                Best practices <strong>85</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>52</strong> Pwa
-          </li>
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_find_a_housing_counselor_-2020_10_05_00_38_53.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_find_a_housing_counselor_-2020_10_05_00_38_53.report.json">
+            View full desktop report
+          </a>
+        </div>
+
       </td>
       
       <td>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_find_a_housing_counselor_-2020_10_05_00_55_16.report.json"
-          >
-            View mobile report
-          </a>
-        </div>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_find_a_housing_counselor_-2020_10_05_00_38_53.report.json"
-          >
-            View desktop report
-          </a>
-        </div>
-        
+        <a class="report-link"
+           href="#">
+          View report history
+          (coming soon)
+        </a>
       </td>
     </tr>
     
@@ -3861,186 +4965,240 @@
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+                
+              
 
-            <strong>95</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_learnmore_-2020_10_05_00_56_06.report.json#performance">
+                Performance <strong>95</strong>
+              </a>
 
-            
-            
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>98</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+                
+              
 
-            
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_learnmore_-2020_10_05_00_56_06.report.json#accessibility">
+                Accessibility <strong>98</strong>
+              </a>
 
-            <strong>85</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_learnmore_-2020_10_05_00_56_06.report.json#best-practices">
+                Best practices <strong>85</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>54</strong> Pwa
-          </li>
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_learnmore_-2020_10_05_00_56_06.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_learnmore_-2020_10_05_00_56_06.report.json">
+            View full mobile report
+          </a>
+        </div>
+
       </td>
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
+            <li class="m-list_item">
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
 
-            
-            
+              
+                
+              
 
-            <strong>68</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_learnmore_-2020_10_05_00_39_42.report.json#performance">
+                Performance <strong>68</strong>
+              </a>
 
-            
-            
+              
+              
 
-            
-            
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>98</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_learnmore_-2020_10_05_00_39_42.report.json#accessibility">
+                Accessibility <strong>98</strong>
+              </a>
 
-            <strong>92</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_learnmore_-2020_10_05_00_39_42.report.json#best-practices">
+                Best practices <strong>92</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>52</strong> Pwa
-          </li>
+              
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_learnmore_-2020_10_05_00_39_42.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_learnmore_-2020_10_05_00_39_42.report.json">
+            View full desktop report
+          </a>
+        </div>
+
       </td>
       
       <td>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_learnmore_-2020_10_05_00_56_06.report.json"
-          >
-            View mobile report
-          </a>
-        </div>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_learnmore_-2020_10_05_00_39_42.report.json"
-          >
-            View desktop report
-          </a>
-        </div>
-        
+        <a class="report-link"
+           href="#">
+          View report history
+          (coming soon)
+        </a>
       </td>
     </tr>
     
@@ -4052,186 +5210,242 @@
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
+            <li class="m-list_item">
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
 
-            
-            
+              
+                
+              
 
-            <strong>67</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_owning_a_home_-2020_10_05_00_56_31.report.json#performance">
+                Performance <strong>67</strong>
+              </a>
 
-            
-            
+              
+              
 
-            
-            
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>95</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+                
+              
 
-            
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_owning_a_home_-2020_10_05_00_56_31.report.json#accessibility">
+                Accessibility <strong>95</strong>
+              </a>
 
-            <strong>85</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>92</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_owning_a_home_-2020_10_05_00_56_31.report.json#best-practices">
+                Best practices <strong>85</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>54</strong> Pwa
-          </li>
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_owning_a_home_-2020_10_05_00_56_31.report.json#seo">
+                SEO <strong>92</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_owning_a_home_-2020_10_05_00_56_31.report.json">
+            View full mobile report
+          </a>
+        </div>
+
       </td>
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
-            <svg class="u-fill-red cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
+              
+                
+              
 
-            <strong>27</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_owning_a_home_-2020_10_05_00_40_25.report.json#performance">
+                Performance <strong>27</strong>
+              </a>
 
-            
-            
+              
+              
+              <svg class="u-fill-red cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>95</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_owning_a_home_-2020_10_05_00_40_25.report.json#accessibility">
+                Accessibility <strong>95</strong>
+              </a>
 
-            <strong>92</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>91</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
-            <svg class="u-fill-red cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
-            
+              
+                
+              
 
-            
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_owning_a_home_-2020_10_05_00_40_25.report.json#best-practices">
+                Best practices <strong>92</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>26</strong> Pwa
-          </li>
+              
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_owning_a_home_-2020_10_05_00_40_25.report.json#seo">
+                SEO <strong>91</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_owning_a_home_-2020_10_05_00_40_25.report.json">
+            View full desktop report
+          </a>
+        </div>
+
       </td>
       
       <td>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_owning_a_home_-2020_10_05_00_56_31.report.json"
-          >
-            View mobile report
-          </a>
-        </div>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_owning_a_home_-2020_10_05_00_40_25.report.json"
-          >
-            View desktop report
-          </a>
-        </div>
-        
+        <a class="report-link"
+           href="#">
+          View report history
+          (coming soon)
+        </a>
       </td>
     </tr>
     
@@ -4243,186 +5457,240 @@
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+                
+              
 
-            <strong>91</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_policy_compliance_rulemaking_regulations_-2020_10_05_00_57_42.report.json#performance">
+                Performance <strong>91</strong>
+              </a>
 
-            
-            
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>97</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+                
+              
 
-            
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_policy_compliance_rulemaking_regulations_-2020_10_05_00_57_42.report.json#accessibility">
+                Accessibility <strong>97</strong>
+              </a>
 
-            <strong>85</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_policy_compliance_rulemaking_regulations_-2020_10_05_00_57_42.report.json#best-practices">
+                Best practices <strong>85</strong>
+              </a>
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+              
 
-            <strong>96</strong> Pwa
-          </li>
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_policy_compliance_rulemaking_regulations_-2020_10_05_00_57_42.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_policy_compliance_rulemaking_regulations_-2020_10_05_00_57_42.report.json">
+            View full mobile report
+          </a>
+        </div>
+
       </td>
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
+            <li class="m-list_item">
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
 
-            
-            
+              
+                
+              
 
-            <strong>54</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_policy_compliance_rulemaking_regulations_-2020_10_05_00_40_53.report.json#performance">
+                Performance <strong>54</strong>
+              </a>
 
-            
-            
+              
+              
 
-            
-            
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>97</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_policy_compliance_rulemaking_regulations_-2020_10_05_00_40_53.report.json#accessibility">
+                Accessibility <strong>97</strong>
+              </a>
 
-            <strong>92</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_policy_compliance_rulemaking_regulations_-2020_10_05_00_40_53.report.json#best-practices">
+                Best practices <strong>92</strong>
+              </a>
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+              
 
-            <strong>96</strong> Pwa
-          </li>
+              
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_policy_compliance_rulemaking_regulations_-2020_10_05_00_40_53.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_policy_compliance_rulemaking_regulations_-2020_10_05_00_40_53.report.json">
+            View full desktop report
+          </a>
+        </div>
+
       </td>
       
       <td>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_policy_compliance_rulemaking_regulations_-2020_10_05_00_57_42.report.json"
-          >
-            View mobile report
-          </a>
-        </div>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_policy_compliance_rulemaking_regulations_-2020_10_05_00_40_53.report.json"
-          >
-            View desktop report
-          </a>
-        </div>
-        
+        <a class="report-link"
+           href="#">
+          View report history
+          (coming soon)
+        </a>
       </td>
     </tr>
     
@@ -4434,186 +5702,240 @@
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+                
+              
 
-            <strong>96</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_start_small_save_up_start_saving_-2020_10_05_00_58_08.report.json#performance">
+                Performance <strong>96</strong>
+              </a>
 
-            
-            
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>98</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+                
+              
 
-            
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_start_small_save_up_start_saving_-2020_10_05_00_58_08.report.json#accessibility">
+                Accessibility <strong>98</strong>
+              </a>
 
-            <strong>85</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_start_small_save_up_start_saving_-2020_10_05_00_58_08.report.json#best-practices">
+                Best practices <strong>85</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>54</strong> Pwa
-          </li>
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_start_small_save_up_start_saving_-2020_10_05_00_58_08.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_start_small_save_up_start_saving_-2020_10_05_00_58_08.report.json">
+            View full mobile report
+          </a>
+        </div>
+
       </td>
       
       <td>
         <ul class="m-list m-list__unstyled">
-          <li class="m-list_item">
+          
+          
 
-            
-            
+            <li class="m-list_item">
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
 
-            
-            
+              
+                
+              
 
-            <strong>69</strong> Performance
-          </li>
-          <li class="m-list_item">
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_start_small_save_up_start_saving_-2020_10_05_00_41_42.report.json#performance">
+                Performance <strong>69</strong>
+              </a>
 
-            
-            
+              
+              
 
-            
-            
+              
+              
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              
 
+            </li>
             
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+          
+          
 
-            <strong>98</strong> Accessibility
-          </li>
-          <li class="m-list_item">
+            <li class="m-list_item">
 
-            
-            
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_start_small_save_up_start_saving_-2020_10_05_00_41_42.report.json#accessibility">
+                Accessibility <strong>98</strong>
+              </a>
 
-            <strong>92</strong> Best-practices
-          </li>
-          <li class="m-list_item">
+              
+              
 
-            
-            
+              
+              
 
+            </li>
             
-            
+          
+          
 
-            
-            
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            
+            <li class="m-list_item">
 
-            <strong>100</strong> Seo
-          </li>
-          <li class="m-list_item">
+              
 
-            
-            
+              
+                
+              
 
-            
-            
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_start_small_save_up_start_saving_-2020_10_05_00_41_42.report.json#best-practices">
+                Best practices <strong>92</strong>
+              </a>
 
-            
-            
+              
+              
 
-            <strong>52</strong> Pwa
-          </li>
+              
+              
+
+            </li>
+            
+          
+          
+
+            <li class="m-list_item">
+
+              
+
+              
+                
+              
+
+              
+              <a class="u-unstyled-link report-link" target="_blank" href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_start_small_save_up_start_saving_-2020_10_05_00_41_42.report.json#seo">
+                SEO <strong>100</strong>
+              </a>
+
+              
+              
+
+              
+              
+
+            </li>
+            
+          
+          
           
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_start_small_save_up_start_saving_-2020_10_05_00_41_42.report.json">
+            View full desktop report
+          </a>
+        </div>
+
       </td>
       
       <td>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_start_small_save_up_start_saving_-2020_10_05_00_58_08.report.json"
-          >
-            View mobile report
-          </a>
-        </div>
-        
-        <div>
-          <a
-            class="report-link"
-            href="reports/2020-10-05T00:58:30.675Z/www_consumerfinance_gov-_start_small_save_up_start_saving_-2020_10_05_00_41_42.report.json"
-          >
-            View desktop report
-          </a>
-        </div>
-        
+        <a class="report-link"
+           href="#">
+          View report history
+          (coming soon)
+        </a>
       </td>
     </tr>
     

--- a/docs/index.html
+++ b/docs/index.html
@@ -270,11 +270,14 @@
       </td>
       
       <td>
+        <em>not available</em>
+        <!-- TODO: Add history reports.
         <a class="report-link"
            href="#">
           View report history
           (coming soon)
         </a>
+        -->
       </td>
     </tr>
     
@@ -521,11 +524,14 @@
       </td>
       
       <td>
+        <em>not available</em>
+        <!-- TODO: Add history reports.
         <a class="report-link"
            href="#">
           View report history
           (coming soon)
         </a>
+        -->
       </td>
     </tr>
     
@@ -768,11 +774,14 @@
       </td>
       
       <td>
+        <em>not available</em>
+        <!-- TODO: Add history reports.
         <a class="report-link"
            href="#">
           View report history
           (coming soon)
         </a>
+        -->
       </td>
     </tr>
     
@@ -1013,11 +1022,14 @@
       </td>
       
       <td>
+        <em>not available</em>
+        <!-- TODO: Add history reports.
         <a class="report-link"
            href="#">
           View report history
           (coming soon)
         </a>
+        -->
       </td>
     </tr>
     
@@ -1260,11 +1272,14 @@
       </td>
       
       <td>
+        <em>not available</em>
+        <!-- TODO: Add history reports.
         <a class="report-link"
            href="#">
           View report history
           (coming soon)
         </a>
+        -->
       </td>
     </tr>
     
@@ -1505,11 +1520,14 @@
       </td>
       
       <td>
+        <em>not available</em>
+        <!-- TODO: Add history reports.
         <a class="report-link"
            href="#">
           View report history
           (coming soon)
         </a>
+        -->
       </td>
     </tr>
     
@@ -1750,11 +1768,14 @@
       </td>
       
       <td>
+        <em>not available</em>
+        <!-- TODO: Add history reports.
         <a class="report-link"
            href="#">
           View report history
           (coming soon)
         </a>
+        -->
       </td>
     </tr>
     
@@ -1995,11 +2016,14 @@
       </td>
       
       <td>
+        <em>not available</em>
+        <!-- TODO: Add history reports.
         <a class="report-link"
            href="#">
           View report history
           (coming soon)
         </a>
+        -->
       </td>
     </tr>
     
@@ -2242,11 +2266,14 @@
       </td>
       
       <td>
+        <em>not available</em>
+        <!-- TODO: Add history reports.
         <a class="report-link"
            href="#">
           View report history
           (coming soon)
         </a>
+        -->
       </td>
     </tr>
     
@@ -2489,11 +2516,14 @@
       </td>
       
       <td>
+        <em>not available</em>
+        <!-- TODO: Add history reports.
         <a class="report-link"
            href="#">
           View report history
           (coming soon)
         </a>
+        -->
       </td>
     </tr>
     
@@ -2736,11 +2766,14 @@
       </td>
       
       <td>
+        <em>not available</em>
+        <!-- TODO: Add history reports.
         <a class="report-link"
            href="#">
           View report history
           (coming soon)
         </a>
+        -->
       </td>
     </tr>
     
@@ -2981,11 +3014,14 @@
       </td>
       
       <td>
+        <em>not available</em>
+        <!-- TODO: Add history reports.
         <a class="report-link"
            href="#">
           View report history
           (coming soon)
         </a>
+        -->
       </td>
     </tr>
     
@@ -3226,11 +3262,14 @@
       </td>
       
       <td>
+        <em>not available</em>
+        <!-- TODO: Add history reports.
         <a class="report-link"
            href="#">
           View report history
           (coming soon)
         </a>
+        -->
       </td>
     </tr>
     
@@ -3471,11 +3510,14 @@
       </td>
       
       <td>
+        <em>not available</em>
+        <!-- TODO: Add history reports.
         <a class="report-link"
            href="#">
           View report history
           (coming soon)
         </a>
+        -->
       </td>
     </tr>
     
@@ -3718,11 +3760,14 @@
       </td>
       
       <td>
+        <em>not available</em>
+        <!-- TODO: Add history reports.
         <a class="report-link"
            href="#">
           View report history
           (coming soon)
         </a>
+        -->
       </td>
     </tr>
     
@@ -3963,11 +4008,14 @@
       </td>
       
       <td>
+        <em>not available</em>
+        <!-- TODO: Add history reports.
         <a class="report-link"
            href="#">
           View report history
           (coming soon)
         </a>
+        -->
       </td>
     </tr>
     
@@ -4210,11 +4258,14 @@
       </td>
       
       <td>
+        <em>not available</em>
+        <!-- TODO: Add history reports.
         <a class="report-link"
            href="#">
           View report history
           (coming soon)
         </a>
+        -->
       </td>
     </tr>
     
@@ -4457,11 +4508,14 @@
       </td>
       
       <td>
+        <em>not available</em>
+        <!-- TODO: Add history reports.
         <a class="report-link"
            href="#">
           View report history
           (coming soon)
         </a>
+        -->
       </td>
     </tr>
     
@@ -4702,11 +4756,14 @@
       </td>
       
       <td>
+        <em>not available</em>
+        <!-- TODO: Add history reports.
         <a class="report-link"
            href="#">
           View report history
           (coming soon)
         </a>
+        -->
       </td>
     </tr>
     
@@ -4949,11 +5006,14 @@
       </td>
       
       <td>
+        <em>not available</em>
+        <!-- TODO: Add history reports.
         <a class="report-link"
            href="#">
           View report history
           (coming soon)
         </a>
+        -->
       </td>
     </tr>
     
@@ -5194,11 +5254,14 @@
       </td>
       
       <td>
+        <em>not available</em>
+        <!-- TODO: Add history reports.
         <a class="report-link"
            href="#">
           View report history
           (coming soon)
         </a>
+        -->
       </td>
     </tr>
     
@@ -5441,11 +5504,14 @@
       </td>
       
       <td>
+        <em>not available</em>
+        <!-- TODO: Add history reports.
         <a class="report-link"
            href="#">
           View report history
           (coming soon)
         </a>
+        -->
       </td>
     </tr>
     
@@ -5686,11 +5752,14 @@
       </td>
       
       <td>
+        <em>not available</em>
+        <!-- TODO: Add history reports.
         <a class="report-link"
            href="#">
           View report history
           (coming soon)
         </a>
+        -->
       </td>
     </tr>
     
@@ -5931,11 +6000,14 @@
       </td>
       
       <td>
+        <em>not available</em>
+        <!-- TODO: Add history reports.
         <a class="report-link"
            href="#">
           View report history
           (coming soon)
         </a>
+        -->
       </td>
     </tr>
     

--- a/docs/static/css/main.css
+++ b/docs/static/css/main.css
@@ -3342,10 +3342,10 @@ a.a-heading__icon.active {
   width: calc(100% - 60px);
 }
 .cfpblh-table td:nth-child(2) {
-  min-width: 160px;
+  min-width: 200px;
 }
 .cfpblh-table td:nth-child(3) {
-  min-width: 160px;
+  min-width: 200px;
 }
 .cfpblh-table td:nth-child(4) {
   vertical-align: top;
@@ -3358,5 +3358,13 @@ a.a-heading__icon.active {
 }
 .u-fill-gold {
   fill: #ff9e1b;
+}
+.u-unstyled-link {
+  font-style: none !important;
+  color: #101820 !important;
+  border-bottom: none !important;
+}
+.u-unstyled-link:hover {
+  color: #0050b4 !important;
 }
 

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -21,12 +21,12 @@
 
 // Second column
 .cfpblh-table td:nth-child(2){
-    min-width: 160px;
+    min-width: 200px;
 }
 
 // Third column
 .cfpblh-table td:nth-child(3){
-    min-width: 160px;
+    min-width: 200px;
 }
 
 // Fourth column
@@ -44,4 +44,14 @@
 
 .u-fill-gold {
     fill: @gold;
+}
+
+.u-unstyled-link {
+    font-style: none !important;
+    color: @black !important;
+    border-bottom: none !important;
+
+    &:hover {
+        color: @pacific-dark !important;
+    }
 }

--- a/src/templates/index.njk
+++ b/src/templates/index.njk
@@ -11,9 +11,9 @@
   <thead>
     <tr>
       <th>Cf.gov Page</th>
-      <th>Mobile scores</th>
-      <th>Desktop scores</th>
-      <th>Reports</th>
+      <th>MOBILE REPORT</th>
+      <th>DESKTOP REPORT</th>
+      <th>HISTORY</th>
     </tr>
   </thead>
   <tbody>
@@ -27,42 +27,58 @@
       <td>
         <ul class="m-list m-list__unstyled">
           {% for metric, score in page.reports.get( report ).summary -%}
-          <li class="m-list_item">
 
-            {# Error icon for less than 50% pass rate. #}
-            {% if score < 0.5 %}
-            <svg class="u-fill-red cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
+          {# Skip PWA #}
+          {% if metric != 'pwa' %}
+
+            <li class="m-list_item">
+
+              {% set metric_display = metric %}
+
+              {% if metric == 'seo' %}
+                {% set metric_display = metric | upper %}
+              {% elif metric == 'best-practices' %}
+                {% set metric_display = 'Best practices' %}
+              {% else %}
+                {% set metric_display = metric | capitalize %}
+              {% endif %}
+
+              {% set report_link = page.reports.get( report ).jsonPath + '#' + metric %}
+              <a class="u-unstyled-link report-link" target="_blank" href="{{ report_link }}">
+                {{ metric_display }} <strong>{{ ( score * 100 ) | round }}</strong>
+              </a>
+
+              {# Error icon for less than 50% pass rate. #}
+              {% if score < 0.5 %}
+              <svg class="u-fill-red cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
+              {% endif %}
+
+              {# Warning icon for between 50% and 90% pass rate. #}
+              {% if score >= 0.5 and score < 0.9 %}
+              <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+              {% endif %}
+
+            </li>
             {% endif %}
-
-            {# Warning icon for between 50% and 90% pass rate. #}
-            {% if score >= 0.5 and score < 0.9 %}
-            <svg class="u-fill-gold cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-            {% endif %}
-
-            {# Success icon for between 50% and 90% pass rate.
-               This icon is visually hidden,
-               but included to occupy space in the layout. #}
-            {% if score >= 0.9 %}
-            <svg class="u-transparent cf-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
-            {% endif %}
-
-            <strong>{{ ( score * 100 ) | round }}</strong> {{ metric | capitalize }}
-          </li>
           {% endfor %}
         </ul>
+
+        <div>
+          <a target="_blank"
+             class="report-link"
+             href="{{ page.reports.get( report ).jsonPath }}">
+            View full {{ report }} report
+          </a>
+        </div>
+
       </td>
       {% endfor %}
       <td>
-        {% for report in reports %}
-        <div>
-          <a
-            class="report-link"
-            href="{{ page.reports.get( report ).jsonPath }}"
-          >
-            View {{ report }} report
-          </a>
-        </div>
-        {% endfor %}
+        <a class="report-link"
+           href="#">
+          View report history
+          (coming soon)
+        </a>
       </td>
     </tr>
     {% endfor %}

--- a/src/templates/index.njk
+++ b/src/templates/index.njk
@@ -74,11 +74,14 @@
       </td>
       {% endfor %}
       <td>
+        <em>not available</em>
+        <!-- TODO: Add history reports.
         <a class="report-link"
            href="#">
           View report history
           (coming soon)
         </a>
+        -->
       </td>
     </tr>
     {% endfor %}


### PR DESCRIPTION
## Changes

- Move desktop/mobile report links to their respective columns.
- Make report line-items links.
- Move icons to the end of line-items.

## Testing

1. `yarn && yarn serve`

## Screenshots

Before:

<img width="1561" alt="Screen Shot 2020-10-05 at 11 40 42 AM" src="https://user-images.githubusercontent.com/704760/95100935-9fa8d080-06ff-11eb-892a-09f72e6e5dcb.png">

After:

<img width="1570" alt="Screen Shot 2020-10-05 at 11 34 13 AM" src="https://user-images.githubusercontent.com/704760/95100074-b995e380-06fe-11eb-90d4-3c7e139e669c.png">
