### PR TITLE
Fix static assets location

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Build the static website
         run: yarn build
+        env:
+          LIGHTHOUSE_RELATIVE_URL: /cfgov-lighthouse
 
       - name: Commit site back to GitHub
         uses: EndBug/add-and-commit@v4

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Build the static website
         run: yarn build
+        env:
+          LIGHTHOUSE_RELATIVE_URL: /cfgov-lighthouse
 
       - name: Commit reports and site back to GitHub
         uses: EndBug/add-and-commit@v4

--- a/src/templates/base.njk
+++ b/src/templates/base.njk
@@ -8,7 +8,7 @@
             <title>consumerfinance.gov lighthouse reports</title>
         {% endblock %}
         {% block css %}
-            <link rel="stylesheet" href="/static/css/main.css">
+            <link rel="stylesheet" href="{{ STATIC_ASSETS_PATH }}/css/main.css">
         {% endblock %}
 
     </head>
@@ -19,7 +19,7 @@
         </main>
 
         {% block js %}
-            <script src="/static/js/main.js"></script>
+            <script src="{{ STATIC_ASSETS_PATH }}/js/main.js"></script>
         {% endblock %}
     </body>
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,10 @@ const filters = require( './scripts/lib/filters' );
 const MiniCssExtractPlugin = require( 'mini-css-extract-plugin' );
 const NunjucksWebpackPlugin = require( 'nunjucks-webpack-plugin' );
 
+// eslint-disable-next-line no-process-env
+const LIGHTHOUSE_RELATIVE_URL = process.env.LIGHTHOUSE_RELATIVE_URL || '';
+const STATIC_ASSETS_PATH = `${ LIGHTHOUSE_RELATIVE_URL }/static`;
+
 // eslint-disable-next-line no-sync
 const allReports = JSON.parse( fs.readFileSync( path.resolve( 'docs/reports.json' ) ) );
 
@@ -30,6 +34,7 @@ function getPageTemplates( reports ) {
       from: './src/templates/page.njk',
       to: `${ slug }/index.html`,
       context: {
+        STATIC_ASSETS_PATH,
         url: summary[Object.keys( summary )[0]].url,
         summaryReport: summary
       }
@@ -53,6 +58,7 @@ function buildReportPlugin( reports ) {
           from: './src/templates/index.njk',
           to: 'index.html',
           context: {
+            STATIC_ASSETS_PATH,
             date: mostRecentDate,
             summaryReport: mostRecentReport
           }


### PR DESCRIPTION
The prod site lives at /cfgov-lighthouse so we have to ensure we point to
the right location. Adds a relative url variable that GitHub Actions defines
before building the site.