### PR TITLE
Fix desktop report link text

### DIFF
--- a/src/templates/index.njk
+++ b/src/templates/index.njk
@@ -84,7 +84,7 @@
           <a target="_blank"
              class="report-link"
              href="reports/{{ results.desktop.jsonPath }}">
-            View full mobile report
+            View full desktop report
           </a>
         </div>
       </td>


### PR DESCRIPTION
The [report index page](https://cfpb.github.io/cfgov-lighthouse/) incorrectly says "View full mobile report" twice, instead of having different links for desktop and mobile.

Before:

![image](https://user-images.githubusercontent.com/654645/97245966-92e53d00-17d2-11eb-81d5-74eb4d2d4af8.png)

After:

![image](https://user-images.githubusercontent.com/654645/97245992-a5f80d00-17d2-11eb-854b-5b93880dbb59.png)