### PR TITLE
Improve create-report-index error reporting

### DIFF
--- a/scripts/create-reports-index.js
+++ b/scripts/create-reports-index.js
@@ -69,6 +69,7 @@ async function buildIndexOfAllReports( reportsRoot ) {
     await fs.writeFile( INDEX_LOCATION, JSON.stringify( index, 0, 2 ) );
     logger.info( `Successfully generated ${ INDEX_LOCATION }.` );
   } catch ( err ) {
-    logger.error( err );
+    logger.error( err.toString() );
+    console.error( err );
   }
 } )();


### PR DESCRIPTION
I was trying out this project and stumbled upon this small thing – hope it helps! Currently `create-report-index` only logs `error: undefined` when it fails:

```
2021-01-04T14:59:53.649Z error: 	undefined
```

## Changes

This change makes it log the error’s type and message, as well as the full stack trace. Sample output:

```
2021-01-04T15:01:15.332Z error: 	TypeError: Cannot read property '1' of null
TypeError: Cannot read property '1' of null
    at /cfgov-lighthouse/scripts/lib/reports.js:81:25
    at Array.map (<anonymous>)
    at processManifestRuns (/cfgov-lighthouse/scripts/lib/reports.js:76:15)
    at reducer (/cfgov-lighthouse/scripts/create-reports-index.js:59:27)
    at async /cfgov-lighthouse/scripts/create-reports-index.js:68:19
```

## Testing

Manually add a `throw new Error()` somewhere inside the `create-reports-index` logic, and watch the command’s output before/after this change.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- ~~[ ] New functions are documented (with a description, list of inputs, and expected output)~~
- ~~[ ] Placeholder code is flagged / future todos are captured in comments~~
- ~~[ ] Visually tested in supported browsers and devices (see checklist below :point_down:)~~
- ~~[ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)~~
- ~~[ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:~~

## Testing checklist

### Browsers

N/A

### Accessibility

N/A

### Other

- ~~[ ] Is useable without CSS~~
- ~~[ ] Is useable without JS~~
- ~~[ ] Flexible from small to large screens~~
- [x] No linting errors or warnings
- [x] JavaScript tests are passing
