### PR TITLE
Better handling of tested URLs with query strings

### DIFF
--- a/scripts/lib/reports.js
+++ b/scripts/lib/reports.js
@@ -1,6 +1,11 @@
 const path = require( 'path' );
 const { promises: fs } = require( 'fs' );
 
+const {
+  getUrlWithoutMobileTestingParameter,
+  hasMobileTestingParameter
+} = require( './urls' );
+
 // Location where the reports are stored, organized by timestamp
 const REPORTS_ROOT = path.resolve( __dirname, '../../docs/reports' );
 
@@ -86,9 +91,9 @@ function processManifestRuns( runs ) {
     return {
       slug,
       date,
-      url: run.url.replace( '?mobile=1', '' ),
+      url: getUrlWithoutMobileTestingParameter( run.url ),
       jsonPath: `${ runDirectory }/${ runFilename }`,
-      formFactor: run.url.includes( '?mobile=1' ) ? 'mobile' : 'desktop',
+      formFactor: hasMobileTestingParameter( run.url ) ? 'mobile' : 'desktop',
       summary: run.summary
     };
   } );

--- a/scripts/lib/urls.js
+++ b/scripts/lib/urls.js
@@ -45,4 +45,30 @@ function getUrls( baseUrl, mobile ) {
   } );
 }
 
-module.exports = { getUrls };
+/**
+ * Remove mobile testing parameter from a URL, if it exists.
+ * @param {string} url URL, e.g. https://www.consumerfinance.gov/?mobile=1.
+ * @returns {URL} URL without mobile testing parameter.
+ */
+function getUrlWithoutMobileTestingParameter( url ) {
+  const urlObj = new URL( url );
+
+  urlObj.searchParams.delete( MOBILE_QUERY_STRING_PARAM );
+
+  return urlObj.href;
+}
+
+/**
+ * Test if a URL has been decorated for mobile testing.
+ * @param {string} url URL, e.g. https://www.consumerfinance.gov.
+ * @returns {boolean} Whether the URL has the ?mobile testing flag.
+ */
+function hasMobileTestingParameter( url ) {
+  return new URL( url ).searchParams.has( MOBILE_QUERY_STRING_PARAM );
+}
+
+module.exports = {
+  getUrls,
+  getUrlWithoutMobileTestingParameter,
+  hasMobileTestingParameter
+};


### PR DESCRIPTION
As reported in https://github.com/cfpb/cfgov-lighthouse/issues/22#issuecomment-754046921, the report generation scripts currently don't work properly if tested URLs have query strings. The logic we use to toggle between desktop and mobile testing involves adding a `?mobile=1` to the tested URL.

The code that runs the test handles this properly if the test URL already has a query string:

https://github.com/cfpb/cfgov-lighthouse/blob/426ae5c6e1f040e02d08b3c53b22de10b4ce885a/scripts/lib/urls.js#L38-L44

but the code that collects the reports for the web viewer currently does not:

https://github.com/cfpb/cfgov-lighthouse/blob/426ae5c6e1f040e02d08b3c53b22de10b4ce885a/scripts/lib/reports.js#L89-L91

This logic will fail if the URL has a different query string that doesn't exactly start with `?mobile=1`.

This commit fixes that logic by using the URL Web API interface to modify/check the URL being tested.