### PR TITLE
ESLint: ignore sort-imports linter rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1254,7 +1254,7 @@ rules:
 
   # Sort import declarations within module.
   sort-imports:
-    - 1
+    - 0
     -
       ignoreCase: false
       ignoreMemberSort: false


### PR DESCRIPTION
`sort-imports` can often break as module names and formats change, and under some circumstances can't be fixed through opposing rules colliding. It's mostly noise in our linter I think, and may obfuscate things more, as related packages can't be arranged together if they aren't alphabetical. Let's turn it off.

## Changes

- ESLint: ignore sort-imports linter rule


## How to test this PR

1. Should be merged after https://github.com/cfpb/consumerfinance.gov/pull/6256