### PR TITLE
Increase maxWaitForLoad timeout to 5 seconds

### DIFF
--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -18,7 +18,8 @@ module.exports = {
       url: getUrls( baseUrl, mobile ),
       settings: {
         formFactor: mobile ? 'mobile' : 'desktop',
-        screenEmulation: { mobile: mobile }
+        screenEmulation: { mobile: mobile },
+        maxWaitForLoad: 5000
       }
     },
     upload: {


### PR DESCRIPTION
Lighthouse reports have been failing with a timeout error (see [thread](https://github.com/GoogleChrome/lighthouse/issues/6512#issuecomment-780805548)). This PR attempts to get around this error by allowing up to 5 seconds wait time for testing the pages loaded.

## Changes

- Increase `maxWaitForLoad` timeout to 5 seconds.

## Testing

1. `yarn lighthouse` should pass… or we can merge and see how it goes on GitHub actions and revert if necessary.
