### PR TITLE
Properly test using desktop preset

### DIFF
--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -16,11 +16,7 @@ module.exports = {
   ci: {
     collect: {
       url: getUrls( baseUrl, mobile ),
-      settings: {
-        formFactor: mobile ? 'mobile' : 'desktop',
-        screenEmulation: { mobile: mobile },
-        maxWaitForLoad: 5000
-      }
+      settings: mobile ? null : { preset: 'desktop' }
     },
     upload: {
       target: 'filesystem',


### PR DESCRIPTION
In the most recent versions of Lighthouse, the configuration settings we were using for desktop testing no longer work. Instead of using `formFactor` and `screenEmulation`, we should use the `"desktop"` preset.

This commit makes that change which properly tests using a desktop form factor; this can be confirmed by looking at the (small) screenshots included as part of a Lighthouse report.

|Before (incorrectly testing using mobile)|Now (correctly testing using desktop)|
|-|-|
|![image](https://user-images.githubusercontent.com/654645/131542685-609b7f25-71c6-4936-8eb8-cbb0d7b9f5bd.png)|![image](https://user-images.githubusercontent.com/654645/131542612-516ba3df-b8ba-42fa-b174-3b54a6d5271d.png)|

With this change, our desktop Performance scores now are in the 90s, which is more consistent with how things work when you run from Chrome developer tools.

![image](https://user-images.githubusercontent.com/654645/131542834-0970d585-f623-4053-809d-59b0310f298d.png)