### PR TITLE
Limit report history to last 30 days

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -26,8 +26,8 @@ jobs:
       - name: Run Lighthouse CLI against specified cf.gov pages
         run: yarn lighthouse
 
-      - name: Index all the Lighthouse reports and generate reports.json
-        run: yarn index-reports
+      - name: Process Lighthouse reports to generate reports.json
+        run: yarn process-reports
 
       - name: Build the static website
         run: yarn build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,8 @@ jobs:
       - name: Run unit tests
         run: yarn test
 
-      - name: Index all the Lighthouse reports and generate reports.json
-        run: yarn index-reports
+      - name: Process Lighthouse reports to generate reports.json
+        run: yarn process-reports
 
       - name: Verify the static website builds without errors
         run: yarn build

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "clean": "rm -rf ./docs/static",
     "compile-dev": "webpack --mode=development",
     "compile-prod": "webpack --mode=production",
-    "index-reports": "node scripts/create-reports-index.js",
+    "process-reports": "node scripts/process-reports.js",
     "lighthouse": "lhci collect && lhci collect --additive --mobile && lhci upload",
     "lint": "eslint --max-warnings=0 lighthouserc.js scripts src webpack.config.js",
     "serve": "concurrently \"yarn serve-html\" \"yarn compile-dev --watch\"",

--- a/scripts/lib/reports.js
+++ b/scripts/lib/reports.js
@@ -10,16 +10,27 @@ const {
 const REPORTS_ROOT = path.resolve( __dirname, '../../docs/reports' );
 
 /**
+ * Get list of Lighthouse report subdirectories.
+ *
+ * @param {String} reportsDir Lighthouse reports directory.
+ * @returns {Array} List of report subdirectories.
+ */
+async function getReportSubdirectories( reportsDir ) {
+  const reportDirs = await fs.readdir( reportsDir, { withFileTypes: true } );
+  return reportDirs.filter( reportDir => reportDir.isDirectory() ).sort();
+}
+
+/**
  * Get list of Lighthouse report manifest locations.
  * @param {String} reportsDir Location of lighthouse reports directory.
  * @returns {Array} List of manifest locations.
  */
 async function getManifests( reportsDir ) {
-  const reportDirs = await fs.readdir( reportsDir, { withFileTypes: true } );
-  const manifests = reportDirs.filter( reportDir => reportDir.isDirectory() )
-    .map( reportDir => `${ reportsDir }/${ reportDir.name }/manifest.json` )
-    .sort();
-  return manifests;
+  const subdirs = await getReportSubdirectories( reportsDir );
+
+  return subdirs.map(
+    reportDir => `${ reportsDir }/${ reportDir.name }/manifest.json`
+  );
 }
 
 /**
@@ -126,11 +137,12 @@ function buildIndex( runs, index = { pages: {}} ) {
 
 module.exports = {
   REPORTS_ROOT,
-  getManifests,
-  readManifest,
-  getRunLocation,
+  buildIndex,
   deleteRun,
   getManifestRuns,
+  getManifests,
+  getReportSubdirectories,
+  getRunLocation,
   processManifestRuns,
-  buildIndex
+  readManifest
 };


### PR DESCRIPTION
This change modifies the existing report processing script so that it only keeps reports from the last 30 days. This prevents the size of this repository from growing in an unbounded manner.

Currently, the repo size exceeds 12GB. For each individual page test, Lighthouse generates an X00 KB JSON file. We have ~19,000 of these (roughly 25 pages x 365 days x 2 reports for mobile/desktop) at this point. The repository also contains the rendered HTML pages for each report.

GitHub's recommended size limit for repositories is discussed [here](https://stackoverflow.com/a/59479166).

Because the repository is so large, the [nightly test-and-commit jobs](https://github.com/cfpb/cfgov-lighthouse/actions/workflows/pages/pages-build-deployment) have been failing, resulting in [the dashboard](https://cfpb.github.io/cfgov-lighthouse/) being out of date since December.

With this change, limiting report history to the last 30 days, the repository is reduced to < 5 GB.

## Todos

This change will only impact the size of the files in the repository - it won't remove them from git history. So there may need to be some further manual git history cleanup even after this PR goes in and the next run cleans up the old files.

## Checklist

- [X] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests