### PR TITLE
Modify GitHub Actions to support deleting files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,9 @@ jobs:
           LIGHTHOUSE_RELATIVE_URL: /cfgov-lighthouse
 
       - name: Commit site back to GitHub
-        uses: EndBug/add-and-commit@v4
+        uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          add: docs
+          file_pattern: docs
+          commit_message: Site rebuild triggered by commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -35,8 +35,9 @@ jobs:
           LIGHTHOUSE_RELATIVE_URL: /cfgov-lighthouse
 
       - name: Commit reports and site back to GitHub
-        uses: EndBug/add-and-commit@v4
+        uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          add: docs
+          file_pattern: docs
+          commit_message: Nightly Lighthouse run
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#41 introduced logic to try to delete reports older than 30 days. The GitHub Action we were using to commit back to the repository ([EndBug/add-and-commit@v4](https://github.com/EndBug/add-and-commit)) doesn't support automatically deleting removed files.

This commit tries using [stefanzweifel/git-auto-commit-action@v4](https://github.com/marketplace/actions/git-auto-commit) instead, which should hopefully properly remove files that were deleted.