### PR TITLE
Automatically install fonts on postinstall

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,5 @@ jobs:
       - name: Process Lighthouse reports to generate reports.json
         run: yarn process-reports
 
-      - name: Download the web fonts
-        run: yarn fonts
-
       - name: Verify the static website builds without errors
         run: yarn build

--- a/README.md
+++ b/README.md
@@ -8,15 +8,6 @@ To serve the Lighthouse Report Summary dashboard on your local machine,
 use the command `yarn && yarn serve` and visit `http://127.0.0.1:8080`
 (hit `ctrl` + `c` when you're ready to stop the server).
 
-This installs the dependencies. If you received an error
-`Module not found: Error: Can't resolve …` in regard to the font files,
-follow the next step to install the fonts.
-
-### Install font files
-
-To install self-hosted fonts locally, place the font files
-in `./static/fonts/`. This can be done with the command `yarn fonts`.
-
 ### Run Lighthouse audit
 
 To run a Lighthouse audit, use the command `yarn lighthouse`. This command

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "clean": "rm -rf ./docs/static",
     "compile-dev": "webpack --mode=development",
     "compile-prod": "webpack --mode=production",
-    "fonts": "./scripts/fonts.sh",
+    "postinstall": "./scripts/fonts.sh",
     "process-reports": "node scripts/process-reports.js",
     "lighthouse": "lhci collect && lhci collect --additive --mobile && lhci upload",
     "lint": "eslint --max-warnings=0 lighthouserc.js scripts src webpack.config.js",

--- a/scripts/fonts.sh
+++ b/scripts/fonts.sh
@@ -4,8 +4,8 @@
 mkdir ./static/
 mkdir ./static/fonts
 cd ./static/fonts
-curl 'https://github.com/cfpb/consumerfinance.gov/blob/main/static.in/cfgov-fonts/fonts/2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2?raw=true' --output '1e9892c0-6927-4412-9874-1b82801ba47a.woff'
-curl 'https://github.com/cfpb/consumerfinance.gov/blob/main/static.in/cfgov-fonts/fonts/2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2?raw=true' --output '2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2'
-curl 'https://github.com/cfpb/consumerfinance.gov/blob/main/static.in/cfgov-fonts/fonts/627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2?raw=true' --output '627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2'
-curl 'https://github.com/cfpb/consumerfinance.gov/blob/main/static.in/cfgov-fonts/fonts/627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2?raw=true' --output 'f26faddb-86cc-4477-a253-1e1287684336.woff'
+curl -s 'https://github.com/cfpb/consumerfinance.gov/blob/main/static.in/cfgov-fonts/fonts/2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2?raw=true' --output '1e9892c0-6927-4412-9874-1b82801ba47a.woff'
+curl -s 'https://github.com/cfpb/consumerfinance.gov/blob/main/static.in/cfgov-fonts/fonts/2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2?raw=true' --output '2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2'
+curl -s 'https://github.com/cfpb/consumerfinance.gov/blob/main/static.in/cfgov-fonts/fonts/627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2?raw=true' --output '627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2'
+curl -s 'https://github.com/cfpb/consumerfinance.gov/blob/main/static.in/cfgov-fonts/fonts/627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2?raw=true' --output 'f26faddb-86cc-4477-a253-1e1287684336.woff'
 cd ../../


### PR DESCRIPTION
Instead of manually installing fonts, just force install them on postinstall. This will fix webpack errors when fonts aren't present.